### PR TITLE
fix: combined signals should re-fire handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 /node_modules
 /.psci_modules
 /output
-/test
 /.psci

--- a/MODULE.md
+++ b/MODULE.md
@@ -2,6 +2,16 @@
 
 ## Module FRP.Rabbit
 
+### Types
+
+    type RabbitEff eff = Eff (ref :: Ref, dom :: DOM | eff)
+
+
+### Values
+
+    runRabbit :: forall a eff. Signal (RabbitEff eff) VTree -> (Node -> RabbitEff eff Unit) -> RabbitEff eff Unit
+
+
 ## Module FRP.Rabbit.Handler
 
 ### Types

--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,7 @@
     "purescript-foldable-traversable": "~0.1.6"
   },
   "devDependencies": {
-    "purescript-dom": "~0.1.1"
+    "purescript-dom": "~0.1.1",
+    "purescript-test-unit": "1.1.5"
   }
 }

--- a/src/FRP/Rabbit/Handler.purs
+++ b/src/FRP/Rabbit/Handler.purs
@@ -10,6 +10,7 @@ import Control.Monad.Eff
 import Control.Monad.Eff.Ref
 import FRP.Rabbit.Signal
 import Data.Traversable(sequence)
+import Data.Maybe
 
 type Handler a eff = a -> (WithRef eff) Unit
 type EventSignal a eff = Signal (WithRef eff) a
@@ -17,11 +18,17 @@ type EventSignal a eff = Signal (WithRef eff) a
 createEventHandler :: forall a eff2 eff. (WithRef eff) { handler :: Handler a eff2, event :: EventSignal a eff2 }
 createEventHandler = do
   ref <- newRef []
+  lastVal <- newRef Nothing
   return { event: Signal (\callback -> do
                              cbs <- readRef ref
                              writeRef ref (callback : cbs)
-                             return unit)
+
+                             val <- readRef lastVal
+                             case val of
+                               Nothing -> return unit
+                               Just v  -> callback v)
          , handler: \a -> do
+              writeRef lastVal $ Just a
               cbs <- readRef ref
               sequence $ (\cb -> cb a) <$> cbs
               return unit

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,0 +1,70 @@
+module Test.Main where
+
+import Test.Unit
+import Test.Unit.Console
+import Data.Array
+import Control.Monad
+import Control.Monad.Trans
+import Control.Monad.Cont.Trans
+import Control.Monad.Eff
+import Control.Monad.Eff.Ref
+import DOM
+import FRP.Rabbit
+import FRP.Rabbit.Handler
+import FRP.Rabbit.Signal
+
+combine :: forall a b c e .
+               (a -> b -> c) ->
+               Signal (Eff (ref :: Ref, dom :: DOM | e)) a ->
+               Signal (Eff (ref :: Ref, dom :: DOM | e)) b ->
+               Signal (Eff (ref :: Ref, dom :: DOM | e)) c
+combine f sigA sigB = do a <- sigA
+                         b <- sigB
+                         return $ f a b
+
+record :: forall a e . RefVal [[a]] -> [a] -> Eff (ref :: Ref, dom :: DOM | e) Unit
+record = \ref -> \n -> do v <- readRef ref
+                          writeRef ref $ v `append` [n]
+
+type TestEff e a = forall e . Eff (ref :: Ref, dom :: DOM, testOutput :: TestOutput | e) a
+
+q f = do ref <- newRef []
+         sigA <- createEventHandler
+         sigB <- createEventHandler
+
+         let testSig = combine (\a b -> [a,b]) sigA.event sigB.event
+
+         runSignal testSig (record ref)
+
+         f sigA.handler sigB.handler
+
+         readRef ref
+
+whenSignalsFire :: forall a e . (Eq a) =>
+                   [[a]] ->
+                  ( (a -> Eff (ref :: Ref, dom :: DOM | e) Unit) ->
+                    (a -> Eff (ref :: Ref, dom :: DOM | e) Unit) ->
+                    Eff (ref :: Ref, dom :: DOM | e) Unit
+                  ) ->
+                  ((Boolean -> Eff (ref :: Ref, dom :: DOM | e) Unit) -> Eff (ref :: Ref, dom :: DOM | e) Unit)
+whenSignalsFire expected f = \done -> do res <- q f
+                                         done (res == expected)
+
+main = runTest do
+         test "callbacks fire regardless of signal change order" do
+               assertFn "signal fired in order a1, b2, a3" $ [[1,2],[3,2]] `whenSignalsFire` \a b -> do a 1
+                                                                                                        b 2
+                                                                                                        a 3
+
+               assertFn "signal fired in order a1, b2, a3" $ [[1,2],[3,2]] `whenSignalsFire` \a b -> do b 2
+                                                                                                        a 1
+                                                                                                        a 3
+
+         test "callbacks fire regardless of signal definition order" do
+               assertFn "signal fired in order a1, b2, a3" $ [[1,2],[3,2]] `whenSignalsFire` \a b -> do a 1
+                                                                                                        b 2
+                                                                                                        a 3
+
+               assertFn "signal fired in order b1, a2, b3" $ [[2,1],[2,3]] `whenSignalsFire` \a b -> do b 1
+                                                                                                        a 2
+                                                                                                        b 3


### PR DESCRIPTION
combined signals should re-fire handlers regardless of signal definition or change order 
(see test cases in test/Main.purs)
